### PR TITLE
Add basic unit tests for webapp

### DIFF
--- a/scorecard-webapp/package.json
+++ b/scorecard-webapp/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.10.0",
@@ -26,9 +27,13 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
+    "jsdom": "^25.0.0",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.13",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "vitest": "^2.1.3",
     "tailwindcss": "^4.1.11",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",

--- a/scorecard-webapp/src/components/AppFooter.test.tsx
+++ b/scorecard-webapp/src/components/AppFooter.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import AppFooter from './AppFooter';
+
+describe('AppFooter', () => {
+  it('renders GitHub link', () => {
+    render(<AppFooter />);
+    const link = screen.getByRole('link', { name: /github/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://github.com/rognoni-ignacio/scorecard');
+  });
+});

--- a/scorecard-webapp/src/components/CourseList/SimpleScorecardSelection.test.tsx
+++ b/scorecard-webapp/src/components/CourseList/SimpleScorecardSelection.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppStateContext } from '../../context/context';
+import SimpleScorecardSelection from './SimpleScorecardSelection';
+import { vi, describe, it, expect } from 'vitest';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('SimpleScorecardSelection', () => {
+  it('starts a simple 9-hole scorecard', () => {
+    const setCourse = vi.fn();
+    render(
+      <AppStateContext.Provider value={{ course: null, setCourse }}>
+        <SimpleScorecardSelection />
+      </AppStateContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByText('9 Holes'));
+
+    expect(setCourse).toHaveBeenCalledWith({
+      name: 'Simple 9 Holes',
+      holes: Array.from({ length: 9 }, (_, i) => ({ number: i + 1, par: 0 })),
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/play');
+  });
+});

--- a/scorecard-webapp/src/context/useAppState.test.tsx
+++ b/scorecard-webapp/src/context/useAppState.test.tsx
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useAppState } from './useAppState';
+import { AppStateContext } from './context';
+import type { ReactNode } from 'react';
+
+describe('useAppState', () => {
+  it('throws when used outside provider', () => {
+    const { result } = renderHook(() => useAppState());
+    expect(result.error).toEqual(new Error('useAppState must be used within an AppStateProvider'));
+  });
+
+  it('returns context when used inside provider', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AppStateContext.Provider value={{ course: null, setCourse: vi.fn() }}>
+        {children}
+      </AppStateContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAppState(), { wrapper });
+    expect(result.current.course).toBeNull();
+  });
+});

--- a/scorecard-webapp/src/test/setup.ts
+++ b/scorecard-webapp/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/scorecard-webapp/vite.config.ts
+++ b/scorecard-webapp/vite.config.ts
@@ -5,4 +5,8 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: process.env.NODE_ENV === 'production' ? '/scorecard/' : '/',
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vitest and testing-library for the webapp
- add tests for AppFooter, useAppState hook and SimpleScorecardSelection

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689100b0b368832285374dc8ccca9cab