### PR TITLE
chore: upgrade to react-router 7

### DIFF
--- a/scorecard-webapp/package-lock.json
+++ b/scorecard-webapp/package-lock.json
@@ -11,7 +11,7 @@
         "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3"
+        "react-router": "^7.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -4716,9 +4716,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
-      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4735,22 +4735,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
-      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.6.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/redent": {

--- a/scorecard-webapp/package.json
+++ b/scorecard-webapp/package.json
@@ -14,7 +14,7 @@
     "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "react-router": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/scorecard-webapp/src/App.tsx
+++ b/scorecard-webapp/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 import Scorecard from "./pages/Scorecard";
 import CourseList from "./components/CourseList/CourseList";
 import NotFound from "./pages/NotFound";

--- a/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
+++ b/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { CourseSummary } from "../../types/CourseSummary";
 import { useAppState } from "../../context/useAppState";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import type { Hole } from "../../types/Hole";
 
 export default function PredefinedCoursesSelection() {

--- a/scorecard-webapp/src/components/CourseList/SearchCourses.tsx
+++ b/scorecard-webapp/src/components/CourseList/SearchCourses.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import type { CourseSummary } from "../../types/CourseSummary";
 import { useAppState } from "../../context/useAppState";
 import type { Hole } from "../../types/Hole";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 export default function SearchCourses() {
   const { setCourse } = useAppState();

--- a/scorecard-webapp/src/components/CourseList/SimpleScorecardSelection.tsx
+++ b/scorecard-webapp/src/components/CourseList/SimpleScorecardSelection.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useAppState } from "../../context/useAppState";
 import type { Hole } from "../../types/Hole";
 

--- a/scorecard-webapp/src/main.tsx
+++ b/scorecard-webapp/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router";
 import { AppStateProvider } from "./context/AppStateContext.tsx";
 import "./index.css";
 import App from "./App.tsx";

--- a/scorecard-webapp/src/pages/NotFound.tsx
+++ b/scorecard-webapp/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export default function NotFound() {
   return (

--- a/scorecard-webapp/src/pages/Scorecard.test.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.test.tsx
@@ -5,7 +5,7 @@ import { AppStateContext } from "../context/context";
 import type { CourseState } from "../context/context";
 import { vi } from "vitest";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   useNavigate: () => vi.fn(),
   useBlocker: () => ({ state: "unblocked", proceed: vi.fn(), reset: vi.fn() }),
 }));

--- a/scorecard-webapp/src/pages/Scorecard.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useAppState } from "../context/useAppState";
-import { useBlocker, useNavigate } from "react-router-dom";
+import { useBlocker, useNavigate } from "react-router";
 
 export default function Scorecard() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- replace `react-router-dom` with `react-router` v7.8.0
- update imports and tests to use new React Router package

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689774f50aa8832284e8782cf87b8503