### PR TITLE
refactor: extract home page into component

### DIFF
--- a/scorecard-webapp/src/App.tsx
+++ b/scorecard-webapp/src/App.tsx
@@ -1,33 +1,12 @@
 import { Routes, Route } from "react-router";
 import Scorecard from "./pages/Scorecard";
-import CourseList from "./components/CourseList/CourseList";
 import NotFound from "./pages/NotFound";
-import AppFooter from "./components/AppFooter";
+import Home from "./pages/Home";
 
 function App() {
   return (
     <Routes>
-      <Route
-        path="/"
-        element={
-          <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
-            <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
-              <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow">
-                <h1 className="w-full text-center text-2xl font-bold text-gray-900">
-                  Simple Scorecard
-                </h1>
-              </div>
-              <div
-                className="flex-1 overflow-y-auto overscroll-contain pt-6 pr-2 pb-6 pl-2"
-                style={{ scrollbarGutter: "stable both-edges" }}
-              >
-                <CourseList />
-              </div>
-              <AppFooter />
-            </div>
-          </div>
-        }
-      />
+      <Route path="/" element={<Home />} />
       <Route path="/play" element={<Scorecard />} />
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/scorecard-webapp/src/pages/Home.tsx
+++ b/scorecard-webapp/src/pages/Home.tsx
@@ -1,0 +1,24 @@
+import CourseList from "../components/CourseList/CourseList";
+import AppFooter from "../components/AppFooter";
+
+export default function Home() {
+  return (
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
+        <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow">
+          <h1 className="w-full text-center text-2xl font-bold text-gray-900">
+            Simple Scorecard
+          </h1>
+        </div>
+        <div
+          className="flex-1 overflow-y-auto overscroll-contain pt-6 pr-2 pb-6 pl-2"
+          style={{ scrollbarGutter: "stable both-edges" }}
+        >
+          <CourseList />
+        </div>
+        <AppFooter />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract root route content into reusable Home component
- simplify App routes by referencing Home component

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68977d8022c483229bfc295e5e6c27da