### PR TITLE
feat: add login page and auth guard

### DIFF
--- a/scorecard-webapp/src/App.tsx
+++ b/scorecard-webapp/src/App.tsx
@@ -4,6 +4,7 @@ import NotFound from "./pages/NotFound";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
 import RequireAuth from "./components/RequireAuth";
+import Profile from "./pages/Profile";
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
       <Route path="/login" element={<Login />} />
       <Route path="/" element={<RequireAuth><Home /></RequireAuth>} />
       <Route path="/play" element={<RequireAuth><Scorecard /></RequireAuth>} />
+      <Route path="/profile" element={<RequireAuth><Profile /></RequireAuth>} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/scorecard-webapp/src/App.tsx
+++ b/scorecard-webapp/src/App.tsx
@@ -2,12 +2,15 @@ import { Routes, Route } from "react-router";
 import Scorecard from "./pages/Scorecard";
 import NotFound from "./pages/NotFound";
 import Home from "./pages/Home";
+import Login from "./pages/Login";
+import RequireAuth from "./components/RequireAuth";
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/play" element={<Scorecard />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/" element={<RequireAuth><Home /></RequireAuth>} />
+      <Route path="/play" element={<RequireAuth><Scorecard /></RequireAuth>} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/scorecard-webapp/src/components/LogoutButton.tsx
+++ b/scorecard-webapp/src/components/LogoutButton.tsx
@@ -3,7 +3,11 @@ import { useLogout } from "../hooks/useLogout";
 export default function LogoutButton() {
   const logout = useLogout();
   return (
-    <button type="button" onClick={logout}>
+    <button
+      type="button"
+      onClick={logout}
+      className="rounded bg-blue-500 p-2 text-white"
+    >
       Logout
     </button>
   );

--- a/scorecard-webapp/src/components/LogoutButton.tsx
+++ b/scorecard-webapp/src/components/LogoutButton.tsx
@@ -1,0 +1,10 @@
+import { useLogout } from "../hooks/useLogout";
+
+export default function LogoutButton() {
+  const logout = useLogout();
+  return (
+    <button type="button" onClick={logout}>
+      Logout
+    </button>
+  );
+}

--- a/scorecard-webapp/src/components/RequireAuth.tsx
+++ b/scorecard-webapp/src/components/RequireAuth.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from "react";
+import { Navigate } from "react-router";
+import { useAppState } from "../context/useAppState";
+
+export default function RequireAuth({ children }: PropsWithChildren) {
+  const { user } = useAppState();
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}

--- a/scorecard-webapp/src/context/AppStateContext.tsx
+++ b/scorecard-webapp/src/context/AppStateContext.tsx
@@ -2,12 +2,14 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { AppStateContext } from "./context";
 import type { CourseState } from "./context";
+import type { User } from "../models/User";
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const [course, setCourse] = useState<CourseState | null>(null);
+  const [user, setUser] = useState<User | null>(null);
 
   return (
-    <AppStateContext.Provider value={{ course, setCourse }}>
+    <AppStateContext.Provider value={{ course, setCourse, user, setUser }}>
       {children}
     </AppStateContext.Provider>
   );

--- a/scorecard-webapp/src/context/context.ts
+++ b/scorecard-webapp/src/context/context.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { Hole } from "../models/Hole";
+import type { User } from "../models/User";
 
 export interface CourseState {
   name: string;
@@ -9,6 +10,8 @@ export interface CourseState {
 type AppState = {
   course: CourseState | null;
   setCourse: (course: CourseState | null) => void;
+  user: User | null;
+  setUser: (user: User | null) => void;
 };
 
 export const AppStateContext = createContext<AppState | undefined>(undefined);

--- a/scorecard-webapp/src/hooks/useLogin.ts
+++ b/scorecard-webapp/src/hooks/useLogin.ts
@@ -1,0 +1,12 @@
+import { useNavigate } from "react-router";
+import { useAppState } from "../context/useAppState";
+import type { User } from "../models/User";
+
+export function useLogin() {
+  const { setUser } = useAppState();
+  const navigate = useNavigate();
+  return (user: User) => {
+    setUser(user);
+    navigate("/");
+  };
+}

--- a/scorecard-webapp/src/hooks/useLogout.ts
+++ b/scorecard-webapp/src/hooks/useLogout.ts
@@ -1,0 +1,11 @@
+import { useNavigate } from "react-router";
+import { useAppState } from "../context/useAppState";
+
+export function useLogout() {
+  const { setUser } = useAppState();
+  const navigate = useNavigate();
+  return () => {
+    setUser(null);
+    navigate("/login");
+  };
+}

--- a/scorecard-webapp/src/models/User.ts
+++ b/scorecard-webapp/src/models/User.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: string;
+  name: string;
+}

--- a/scorecard-webapp/src/pages/Home.tsx
+++ b/scorecard-webapp/src/pages/Home.tsx
@@ -1,14 +1,19 @@
 import CourseList from "../components/CourseList/CourseList";
 import AppFooter from "../components/AppFooter";
+import { Link } from "react-router";
 
 export default function Home() {
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
       <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
         <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow">
-          <h1 className="w-full text-center text-2xl font-bold text-gray-900">
+          <div className="flex-1" />
+          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900">
             Simple Scorecard
           </h1>
+          <Link to="/profile" className="flex-1 text-right text-sm text-blue-500">
+            Profile
+          </Link>
         </div>
         <div
           className="flex-1 overflow-y-auto overscroll-contain pt-6 pr-2 pb-6 pl-2"

--- a/scorecard-webapp/src/pages/Login.test.tsx
+++ b/scorecard-webapp/src/pages/Login.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import Login from "./Login";
+import { AppStateContext } from "../context/context";
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+test("renders app name and description", () => {
+  render(
+    <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn() }}>
+      <Login />
+    </AppStateContext.Provider>,
+  );
+
+  expect(
+    screen.getByRole("heading", { name: /simple scorecard/i }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/track your golf scores with ease/i),
+  ).toBeInTheDocument();
+});

--- a/scorecard-webapp/src/pages/Login.tsx
+++ b/scorecard-webapp/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from "react";
 import { useLogin } from "../hooks/useLogin";
+import AppFooter from "../components/AppFooter";
 
 export default function Login() {
   const [name, setName] = useState("");
@@ -13,28 +14,29 @@ export default function Login() {
   };
 
   return (
-    <div className="flex h-dvh w-full items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm rounded bg-white p-6 shadow">
-        <h1 className="mb-2 text-center text-2xl font-bold text-gray-900">
-          Simple Scorecard
-        </h1>
-        <p className="mb-6 text-center text-gray-600">
-          Track your golf scores with ease.
-        </p>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Name"
-            className="rounded border p-2"
-          />
-          <button
-            type="submit"
-            className="rounded bg-blue-500 p-2 text-white"
-          >
-            Login
-          </button>
-        </form>
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
+        <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow">
+          <h1 className="text-2xl font-bold text-gray-900">Simple Scorecard</h1>
+        </div>
+        <div className="flex flex-1 flex-col justify-center gap-6 p-6">
+          <p className="text-center text-gray-600">Track your golf scores with ease.</p>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Name"
+              className="rounded border p-2"
+            />
+            <button
+              type="submit"
+              className="rounded bg-blue-500 p-2 text-white"
+            >
+              Login
+            </button>
+          </form>
+        </div>
+        <AppFooter />
       </div>
     </div>
   );

--- a/scorecard-webapp/src/pages/Login.tsx
+++ b/scorecard-webapp/src/pages/Login.tsx
@@ -14,20 +14,28 @@ export default function Login() {
 
   return (
     <div className="flex h-dvh w-full items-center justify-center bg-gray-50">
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Name"
-          className="rounded border p-2"
-        />
-        <button
-          type="submit"
-          className="rounded bg-blue-500 p-2 text-white"
-        >
-          Login
-        </button>
-      </form>
+      <div className="w-full max-w-sm rounded bg-white p-6 shadow">
+        <h1 className="mb-2 text-center text-2xl font-bold text-gray-900">
+          Simple Scorecard
+        </h1>
+        <p className="mb-6 text-center text-gray-600">
+          Track your golf scores with ease.
+        </p>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name"
+            className="rounded border p-2"
+          />
+          <button
+            type="submit"
+            className="rounded bg-blue-500 p-2 text-white"
+          >
+            Login
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/scorecard-webapp/src/pages/Login.tsx
+++ b/scorecard-webapp/src/pages/Login.tsx
@@ -1,0 +1,33 @@
+import { FormEvent, useState } from "react";
+import { useLogin } from "../hooks/useLogin";
+
+export default function Login() {
+  const [name, setName] = useState("");
+  const login = useLogin();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    login({ id: crypto.randomUUID(), name: trimmed });
+  };
+
+  return (
+    <div className="flex h-dvh w-full items-center justify-center bg-gray-50">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+          className="rounded border p-2"
+        />
+        <button
+          type="submit"
+          className="rounded bg-blue-500 p-2 text-white"
+        >
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/scorecard-webapp/src/pages/Profile.test.tsx
+++ b/scorecard-webapp/src/pages/Profile.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { AppStateContext } from "../context/context";
+import Profile from "./Profile";
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+test("shows user info and allows logout", async () => {
+  const setUser = vi.fn();
+  render(
+    <AppStateContext.Provider
+      value={{ user: { id: "123", name: "Alice" }, setUser, course: null, setCourse: vi.fn() }}
+    >
+      <Profile />
+    </AppStateContext.Provider>,
+  );
+
+  expect(screen.getByText(/alice/i)).toBeInTheDocument();
+  expect(screen.getByText(/123/)).toBeInTheDocument();
+
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /logout/i }));
+  expect(setUser).toHaveBeenCalledWith(null);
+});

--- a/scorecard-webapp/src/pages/Profile.test.tsx
+++ b/scorecard-webapp/src/pages/Profile.test.tsx
@@ -4,11 +4,12 @@ import { vi } from "vitest";
 import { AppStateContext } from "../context/context";
 import Profile from "./Profile";
 
+const mockNavigate = vi.fn();
 vi.mock("react-router", () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
 }));
 
-test("shows user info and allows logout", async () => {
+test("shows user info and allows navigation and logout", async () => {
   const setUser = vi.fn();
   render(
     <AppStateContext.Provider
@@ -22,6 +23,9 @@ test("shows user info and allows logout", async () => {
   expect(screen.getByText(/123/)).toBeInTheDocument();
 
   const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /back/i }));
+  expect(mockNavigate).toHaveBeenCalledWith("/");
+
   await user.click(screen.getByRole("button", { name: /logout/i }));
   expect(setUser).toHaveBeenCalledWith(null);
 });

--- a/scorecard-webapp/src/pages/Profile.tsx
+++ b/scorecard-webapp/src/pages/Profile.tsx
@@ -1,21 +1,43 @@
 import LogoutButton from "../components/LogoutButton";
+import AppFooter from "../components/AppFooter";
 import { useAppState } from "../context/useAppState";
+import { useNavigate } from "react-router";
 
 export default function Profile() {
   const { user } = useAppState();
+  const navigate = useNavigate();
   if (!user) return null;
 
+  const handleGoBack = () => {
+    navigate("/");
+  };
+
   return (
-    <div className="flex h-dvh w-full items-center justify-center bg-gray-50">
-      <div className="flex flex-col gap-4 rounded bg-white p-6 shadow">
-        <h1 className="text-xl font-bold text-gray-900">Profile</h1>
-        <p>
-          <span className="font-semibold">Name:</span> {user.name}
-        </p>
-        <p>
-          <span className="font-semibold">ID:</span> {user.id}
-        </p>
-        <LogoutButton />
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
+        <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow">
+          <button
+            className="cursor-pointer rounded-lg bg-gray-200 px-4 py-2 transition-colors hover:bg-gray-300"
+            onClick={handleGoBack}
+            aria-label="Back"
+          >
+            ←
+          </button>
+          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900">
+            Profile
+          </h1>
+          <div className="w-12" />
+        </div>
+        <div className="flex-1 overflow-y-auto overscroll-contain p-6">
+          <p className="mb-2">
+            <span className="font-semibold">Name:</span> {user.name}
+          </p>
+          <p className="mb-4">
+            <span className="font-semibold">ID:</span> {user.id}
+          </p>
+          <LogoutButton />
+        </div>
+        <AppFooter />
       </div>
     </div>
   );

--- a/scorecard-webapp/src/pages/Profile.tsx
+++ b/scorecard-webapp/src/pages/Profile.tsx
@@ -1,0 +1,22 @@
+import LogoutButton from "../components/LogoutButton";
+import { useAppState } from "../context/useAppState";
+
+export default function Profile() {
+  const { user } = useAppState();
+  if (!user) return null;
+
+  return (
+    <div className="flex h-dvh w-full items-center justify-center bg-gray-50">
+      <div className="flex flex-col gap-4 rounded bg-white p-6 shadow">
+        <h1 className="text-xl font-bold text-gray-900">Profile</h1>
+        <p>
+          <span className="font-semibold">Name:</span> {user.name}
+        </p>
+        <p>
+          <span className="font-semibold">ID:</span> {user.id}
+        </p>
+        <LogoutButton />
+      </div>
+    </div>
+  );
+}

--- a/scorecard-webapp/src/pages/Scorecard.test.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.test.tsx
@@ -12,8 +12,9 @@ vi.mock("react-router", () => ({
 
 function renderScorecard(course: CourseState) {
   const setCourse = vi.fn();
+  const setUser = vi.fn();
   render(
-    <AppStateContext.Provider value={{ course, setCourse }}>
+    <AppStateContext.Provider value={{ course, setCourse, user: null, setUser }}>
       <Scorecard />
     </AppStateContext.Provider>,
   );


### PR DESCRIPTION
## Summary
- add id to user model and navigate after login/logout
- introduce login page and route guard
- protect routes and redirect unauthenticated users

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68978eb67dd883229ce68ed412aa18de