### PR TITLE
Add signup page and password field to login

### DIFF
--- a/scorecard-webapp/src/App.tsx
+++ b/scorecard-webapp/src/App.tsx
@@ -3,6 +3,7 @@ import Scorecard from "./pages/Scorecard";
 import NotFound from "./pages/NotFound";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
+import Signup from "./pages/Signup";
 import RequireAuth from "./components/RequireAuth";
 import Profile from "./pages/Profile";
 
@@ -10,6 +11,7 @@ function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<Signup />} />
       <Route path="/" element={<RequireAuth><Home /></RequireAuth>} />
       <Route path="/play" element={<RequireAuth><Scorecard /></RequireAuth>} />
       <Route path="/profile" element={<RequireAuth><Profile /></RequireAuth>} />

--- a/scorecard-webapp/src/pages/Login.tsx
+++ b/scorecard-webapp/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react";
+import { type FormEvent, useState } from "react";
 import { Link } from "react-router";
 import { useLogin } from "../hooks/useLogin";
 import AppFooter from "../components/AppFooter";
@@ -21,8 +21,10 @@ export default function Login() {
         <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow">
           <h1 className="text-2xl font-bold text-gray-900">Simple Scorecard</h1>
         </div>
-        <div className="flex flex-1 flex-col justify-center gap-6 p-6">
-          <p className="text-center text-gray-600">Track your golf scores with ease.</p>
+        <div className="flex flex-1 flex-col gap-6 p-6">
+          <p className="text-center text-gray-600">
+            Track your golf scores with ease.
+          </p>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <input
               value={name}
@@ -45,7 +47,7 @@ export default function Login() {
             </button>
           </form>
           <p className="text-center text-sm text-gray-600">
-            Don't have an account?{' '}
+            Don't have an account?{" "}
             <Link to="/signup" className="text-blue-500">
               Sign up
             </Link>

--- a/scorecard-webapp/src/pages/Signup.test.tsx
+++ b/scorecard-webapp/src/pages/Signup.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { vi } from "vitest";
-import Login from "./Login";
+import Signup from "./Signup";
 import { AppStateContext } from "../context/context";
 
 vi.mock("react-router", () => ({
@@ -9,18 +9,14 @@ vi.mock("react-router", () => ({
   Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
 }));
 
-test("renders app name and description", () => {
+test("renders signup form", () => {
   render(
     <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn() }}>
-      <Login />
+      <Signup />
     </AppStateContext.Provider>,
   );
 
-  expect(
-    screen.getByRole("heading", { name: /simple scorecard/i }),
-  ).toBeInTheDocument();
-  expect(
-    screen.getByText(/track your golf scores with ease/i),
-  ).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/name/i)).toBeInTheDocument();
   expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /sign up/i })).toBeInTheDocument();
 });

--- a/scorecard-webapp/src/pages/Signup.tsx
+++ b/scorecard-webapp/src/pages/Signup.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react";
+import { type FormEvent, useState } from "react";
 import { Link } from "react-router";
 import { useLogin } from "../hooks/useLogin";
 import AppFooter from "../components/AppFooter";
@@ -21,8 +21,10 @@ export default function Signup() {
         <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow">
           <h1 className="text-2xl font-bold text-gray-900">Simple Scorecard</h1>
         </div>
-        <div className="flex flex-1 flex-col justify-center gap-6 p-6">
-          <p className="text-center text-gray-600">Create an account to start tracking your golf scores.</p>
+        <div className="flex flex-1 flex-col gap-6 p-6">
+          <p className="text-center text-gray-600">
+            Create an account to start tracking your golf scores.
+          </p>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <input
               value={name}
@@ -45,7 +47,7 @@ export default function Signup() {
             </button>
           </form>
           <p className="text-center text-sm text-gray-600">
-            Already have an account?{' '}
+            Already have an account?{" "}
             <Link to="/login" className="text-blue-500">
               Login
             </Link>

--- a/scorecard-webapp/src/pages/Signup.tsx
+++ b/scorecard-webapp/src/pages/Signup.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import { useLogin } from "../hooks/useLogin";
 import AppFooter from "../components/AppFooter";
 
-export default function Login() {
+export default function Signup() {
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const login = useLogin();
@@ -22,7 +22,7 @@ export default function Login() {
           <h1 className="text-2xl font-bold text-gray-900">Simple Scorecard</h1>
         </div>
         <div className="flex flex-1 flex-col justify-center gap-6 p-6">
-          <p className="text-center text-gray-600">Track your golf scores with ease.</p>
+          <p className="text-center text-gray-600">Create an account to start tracking your golf scores.</p>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <input
               value={name}
@@ -41,13 +41,13 @@ export default function Login() {
               type="submit"
               className="rounded bg-blue-500 p-2 text-white"
             >
-              Login
+              Sign Up
             </button>
           </form>
           <p className="text-center text-sm text-gray-600">
-            Don't have an account?{' '}
-            <Link to="/signup" className="text-blue-500">
-              Sign up
+            Already have an account?{' '}
+            <Link to="/login" className="text-blue-500">
+              Login
             </Link>
           </p>
         </div>


### PR DESCRIPTION
## Summary
- extend login with password input and link to signup
- add new signup page and accompanying tests
- wire signup route into app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c40e426483228c83f0f7d43bf5c7