### PR TITLE
feat: add light and dark themes

### DIFF
--- a/scorecard-webapp/index.html
+++ b/scorecard-webapp/index.html
@@ -7,6 +7,10 @@
     <title>Simple Scorecard</title>
   </head>
   <body>
+    <script>
+      const theme = localStorage.getItem('theme');
+      if (theme === 'dark') document.documentElement.classList.add('dark');
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/scorecard-webapp/postcss.config.mjs
+++ b/scorecard-webapp/postcss.config.mjs
@@ -1,5 +1,5 @@
 export default {
   plugins: {
-    "@tailwindcss/postcss": { config: "./tailwind.config.js" },
+    "@tailwindcss/postcss": {},
   },
 };

--- a/scorecard-webapp/postcss.config.mjs
+++ b/scorecard-webapp/postcss.config.mjs
@@ -1,5 +1,5 @@
 export default {
-    plugins: {
-      "@tailwindcss/postcss": {},
-    }
-  }
+  plugins: {
+    "@tailwindcss/postcss": { config: "./tailwind.config.js" },
+  },
+};

--- a/scorecard-webapp/src/App.tsx
+++ b/scorecard-webapp/src/App.tsx
@@ -12,9 +12,30 @@ function App() {
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<Signup />} />
-      <Route path="/" element={<RequireAuth><Home /></RequireAuth>} />
-      <Route path="/play" element={<RequireAuth><Scorecard /></RequireAuth>} />
-      <Route path="/profile" element={<RequireAuth><Profile /></RequireAuth>} />
+      <Route
+        path="/"
+        element={
+          <RequireAuth>
+            <Home />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/play"
+        element={
+          <RequireAuth>
+            <Scorecard />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/profile"
+        element={
+          <RequireAuth>
+            <Profile />
+          </RequireAuth>
+        }
+      />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/scorecard-webapp/src/components/AppFooter.test.tsx
+++ b/scorecard-webapp/src/components/AppFooter.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 import AppFooter from "./AppFooter";
+import { AppStateContext } from "../context/context";
 
 test("renders link to GitHub repository", () => {
-  render(<AppFooter />);
+  render(
+    <AppStateContext.Provider
+      value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}
+    >
+      <AppFooter />
+    </AppStateContext.Provider>
+  );
   const link = screen.getByRole("link", { name: /github/i });
   expect(link).toHaveAttribute(
     "href",

--- a/scorecard-webapp/src/components/AppFooter.test.tsx
+++ b/scorecard-webapp/src/components/AppFooter.test.tsx
@@ -6,10 +6,17 @@ import { AppStateContext } from "../context/context";
 test("renders link to GitHub repository", () => {
   render(
     <AppStateContext.Provider
-      value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}
+      value={{
+        user: null,
+        setUser: vi.fn(),
+        course: null,
+        setCourse: vi.fn(),
+        theme: "light",
+        setTheme: vi.fn(),
+      }}
     >
       <AppFooter />
-    </AppStateContext.Provider>
+    </AppStateContext.Provider>,
   );
   const link = screen.getByRole("link", { name: /github/i });
   expect(link).toHaveAttribute(

--- a/scorecard-webapp/src/components/AppFooter.tsx
+++ b/scorecard-webapp/src/components/AppFooter.tsx
@@ -31,7 +31,7 @@ export default function AppFooter() {
         aria-label="Toggle theme"
         className="ml-2 cursor-pointer rounded p-1 text-gray-500 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
       >
-        {theme === "light" ? "🌙" : "☀️"}
+        {theme === "light" ? "☀️" : "🌙"}
       </button>
     </footer>
   );

--- a/scorecard-webapp/src/components/AppFooter.tsx
+++ b/scorecard-webapp/src/components/AppFooter.tsx
@@ -1,12 +1,17 @@
+import { useAppState } from "../context/useAppState";
+
 export default function AppFooter() {
+  const { theme, setTheme } = useAppState();
+  const toggleTheme = () => setTheme(theme === "light" ? "dark" : "light");
+
   return (
-    <footer className="flex items-center justify-center gap-2 p-2 text-xs text-gray-400">
+    <footer className="flex items-center justify-center gap-2 p-2 text-xs text-gray-400 dark:text-gray-500">
       Made with <span className="text-red-500">♥</span> by Ignacio Rognoni
       <a
         href="https://github.com/rognoni-ignacio/scorecard"
         target="_blank"
         rel="noopener noreferrer"
-        className="ml-1 hover:text-gray-600"
+        className="ml-1 hover:text-gray-600 dark:hover:text-gray-300"
         aria-label="GitHub"
       >
         <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
@@ -21,6 +26,13 @@ export default function AppFooter() {
           />
         </svg>
       </a>
+      <button
+        onClick={toggleTheme}
+        aria-label="Toggle theme"
+        className="ml-2 cursor-pointer rounded p-1 text-gray-500 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        {theme === "light" ? "🌙" : "☀️"}
+      </button>
     </footer>
   );
 }

--- a/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
+++ b/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
@@ -35,12 +35,12 @@ export default function PredefinedCoursesSelection() {
   };
 
   if (loading) {
-    return <div className="text-center text-gray-500">Loading courses...</div>;
+    return <div className="text-center text-gray-500 dark:text-gray-400">Loading courses...</div>;
   }
 
   return (
     <div>
-      <h2 className="mb-2 text-center text-lg font-medium text-gray-700">
+      <h2 className="mb-2 text-center text-lg font-medium text-gray-700 dark:text-gray-300">
         Predefined courses
       </h2>
       <div className="space-y-3">
@@ -48,7 +48,7 @@ export default function PredefinedCoursesSelection() {
           <button
             key={course.id}
             onClick={() => handleSelectCourse(course.id)}
-            className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100"
+            className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900 dark:text-blue-100 dark:hover:border-blue-600 dark:hover:bg-blue-800"
           >
             {course.name}
           </button>

--- a/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
+++ b/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
@@ -35,7 +35,11 @@ export default function PredefinedCoursesSelection() {
   };
 
   if (loading) {
-    return <div className="text-center text-gray-500 dark:text-gray-400">Loading courses...</div>;
+    return (
+      <div className="text-center text-gray-500 dark:text-gray-400">
+        Loading courses...
+      </div>
+    );
   }
 
   return (

--- a/scorecard-webapp/src/components/CourseList/SearchCourses.tsx
+++ b/scorecard-webapp/src/components/CourseList/SearchCourses.tsx
@@ -74,10 +74,14 @@ export default function SearchCourses() {
         </button>
       </form>
       {searchLoading && (
-        <div className="text-center text-gray-500 dark:text-gray-400">Searching courses...</div>
+        <div className="text-center text-gray-500 dark:text-gray-400">
+          Searching courses...
+        </div>
       )}
       {noCoursesFound && (
-        <div className="text-center text-gray-500 dark:text-gray-400">No courses found.</div>
+        <div className="text-center text-gray-500 dark:text-gray-400">
+          No courses found.
+        </div>
       )}
       {searchedCourses.length > 0 && (
         <div className="mt-2 space-y-3">

--- a/scorecard-webapp/src/components/CourseList/SearchCourses.tsx
+++ b/scorecard-webapp/src/components/CourseList/SearchCourses.tsx
@@ -55,7 +55,7 @@ export default function SearchCourses() {
 
   return (
     <div>
-      <h2 className="mb-2 text-center text-lg font-medium text-gray-700">
+      <h2 className="mb-2 text-center text-lg font-medium text-gray-700 dark:text-gray-300">
         Search
       </h2>
       <form onSubmit={searchCoursesAction} className="mb-2 flex gap-2">
@@ -64,20 +64,20 @@ export default function SearchCourses() {
           placeholder="Course name..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full rounded-lg border-2 border-gray-300 bg-white px-4 py-3 text-gray-700 focus:border-blue-500 focus:outline-none"
+          className="w-full rounded-lg border-2 border-gray-300 bg-white px-4 py-3 text-gray-700 focus:border-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
         />
         <button
           type="submit"
-          className="cursor-pointer rounded-lg border-2 border-blue-500 bg-blue-500 px-4 py-3 font-medium text-white transition-colors hover:border-blue-600 hover:bg-blue-600"
+          className="cursor-pointer rounded-lg border-2 border-blue-500 bg-blue-500 px-4 py-3 font-medium text-white transition-colors hover:border-blue-600 hover:bg-blue-600 dark:border-blue-600 dark:bg-blue-600 dark:hover:border-blue-700 dark:hover:bg-blue-700"
         >
           Search
         </button>
       </form>
       {searchLoading && (
-        <div className="text-center text-gray-500">Searching courses...</div>
+        <div className="text-center text-gray-500 dark:text-gray-400">Searching courses...</div>
       )}
       {noCoursesFound && (
-        <div className="text-center text-gray-500">No courses found.</div>
+        <div className="text-center text-gray-500 dark:text-gray-400">No courses found.</div>
       )}
       {searchedCourses.length > 0 && (
         <div className="mt-2 space-y-3">
@@ -85,7 +85,7 @@ export default function SearchCourses() {
             <button
               key={course.id}
               onClick={() => handleSelectExternalCourse(course.id)}
-              className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100"
+              className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900 dark:text-blue-100 dark:hover:border-blue-600 dark:hover:bg-blue-800"
             >
               {course.name}
             </button>

--- a/scorecard-webapp/src/components/CourseList/SimpleScorecardSelection.tsx
+++ b/scorecard-webapp/src/components/CourseList/SimpleScorecardSelection.tsx
@@ -19,13 +19,13 @@ export default function SimpleScorecardSelection() {
       <div className="space-y-3">
         <button
           onClick={() => startSimpleScorecard(9)}
-          className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100"
+          className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900 dark:text-blue-100 dark:hover:border-blue-600 dark:hover:bg-blue-800"
         >
           9 Holes
         </button>
         <button
           onClick={() => startSimpleScorecard(18)}
-          className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100"
+          className="w-full cursor-pointer rounded-lg border-2 border-blue-200 bg-blue-50 px-4 py-3 font-medium text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900 dark:text-blue-100 dark:hover:border-blue-600 dark:hover:bg-blue-800"
         >
           18 Holes
         </button>

--- a/scorecard-webapp/src/components/LogoutButton.tsx
+++ b/scorecard-webapp/src/components/LogoutButton.tsx
@@ -6,7 +6,7 @@ export default function LogoutButton() {
     <button
       type="button"
       onClick={logout}
-      className="cursor-pointer rounded bg-blue-500 p-2 text-white"
+      className="cursor-pointer rounded bg-blue-500 p-2 text-white dark:bg-blue-600"
     >
       Logout
     </button>

--- a/scorecard-webapp/src/context/AppStateContext.tsx
+++ b/scorecard-webapp/src/context/AppStateContext.tsx
@@ -7,10 +7,11 @@ import type { User } from "../models/User";
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const [course, setCourse] = useState<CourseState | null>(null);
   const [user, setUser] = useState<User | null>(null);
-  const [theme, setTheme] = useState<"light" | "dark">(() =>
-    (typeof window !== "undefined" &&
-      (localStorage.getItem("theme") as "light" | "dark")) ||
-    "light",
+  const [theme, setTheme] = useState<"light" | "dark">(
+    () =>
+      (typeof window !== "undefined" &&
+        (localStorage.getItem("theme") as "light" | "dark")) ||
+      "light",
   );
 
   useEffect(() => {

--- a/scorecard-webapp/src/context/AppStateContext.tsx
+++ b/scorecard-webapp/src/context/AppStateContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AppStateContext } from "./context";
 import type { CourseState } from "./context";
 import type { User } from "../models/User";
@@ -7,9 +7,21 @@ import type { User } from "../models/User";
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const [course, setCourse] = useState<CourseState | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [theme, setTheme] = useState<"light" | "dark">(() =>
+    (typeof window !== "undefined" &&
+      (localStorage.getItem("theme") as "light" | "dark")) ||
+    "light",
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
 
   return (
-    <AppStateContext.Provider value={{ course, setCourse, user, setUser }}>
+    <AppStateContext.Provider
+      value={{ course, setCourse, user, setUser, theme, setTheme }}
+    >
       {children}
     </AppStateContext.Provider>
   );

--- a/scorecard-webapp/src/context/context.ts
+++ b/scorecard-webapp/src/context/context.ts
@@ -12,6 +12,8 @@ type AppState = {
   setCourse: (course: CourseState | null) => void;
   user: User | null;
   setUser: (user: User | null) => void;
+  theme: "light" | "dark";
+  setTheme: (theme: "light" | "dark") => void;
 };
 
 export const AppStateContext = createContext<AppState | undefined>(undefined);

--- a/scorecard-webapp/src/index.css
+++ b/scorecard-webapp/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@config "../tailwind.config.js";
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/scorecard-webapp/src/index.css
+++ b/scorecard-webapp/src/index.css
@@ -8,6 +8,10 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+html.dark {
+  color-scheme: dark;
+}
+
 html,
 body {
   height: 100%;

--- a/scorecard-webapp/src/index.css
+++ b/scorecard-webapp/src/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@config "../tailwind.config.js";
+@custom-variant dark (&:where(.dark, .dark *));
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/scorecard-webapp/src/pages/Home.tsx
+++ b/scorecard-webapp/src/pages/Home.tsx
@@ -11,7 +11,10 @@ export default function Home() {
           <h1 className="flex-1 text-center text-2xl font-bold text-gray-900 dark:text-gray-100">
             Simple Scorecard
           </h1>
-          <Link to="/profile" className="flex-1 text-right text-sm text-blue-500 dark:text-blue-400">
+          <Link
+            to="/profile"
+            className="flex-1 text-right text-sm text-blue-500 dark:text-blue-400"
+          >
             Profile
           </Link>
         </div>
@@ -26,4 +29,3 @@ export default function Home() {
     </div>
   );
 }
-

--- a/scorecard-webapp/src/pages/Home.tsx
+++ b/scorecard-webapp/src/pages/Home.tsx
@@ -4,14 +4,14 @@ import { Link } from "react-router";
 
 export default function Home() {
   return (
-    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
-      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
-        <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow">
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50 dark:bg-gray-950">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-900">
+        <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow dark:bg-gray-900">
           <div className="flex-1" />
-          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900">
+          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900 dark:text-gray-100">
             Simple Scorecard
           </h1>
-          <Link to="/profile" className="flex-1 text-right text-sm text-blue-500">
+          <Link to="/profile" className="flex-1 text-right text-sm text-blue-500 dark:text-blue-400">
             Profile
           </Link>
         </div>

--- a/scorecard-webapp/src/pages/Login.test.tsx
+++ b/scorecard-webapp/src/pages/Login.test.tsx
@@ -11,7 +11,7 @@ vi.mock("react-router", () => ({
 
 test("renders app name and description", () => {
   render(
-    <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn() }}>
+    <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}>
       <Login />
     </AppStateContext.Provider>,
   );

--- a/scorecard-webapp/src/pages/Login.tsx
+++ b/scorecard-webapp/src/pages/Login.tsx
@@ -16,13 +16,13 @@ export default function Login() {
   };
 
   return (
-    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
-      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
-        <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow">
-          <h1 className="text-2xl font-bold text-gray-900">Simple Scorecard</h1>
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50 dark:bg-gray-950">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-900">
+        <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow dark:bg-gray-900">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Simple Scorecard</h1>
         </div>
         <div className="flex flex-1 flex-col gap-6 p-6">
-          <p className="text-center text-gray-600">
+          <p className="text-center text-gray-600 dark:text-gray-400">
             Track your golf scores with ease
           </p>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -30,26 +30,26 @@ export default function Login() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Name"
-              className="rounded border p-2"
+              className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Password"
-              className="rounded border p-2"
+              className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
             <button
               type="submit"
-              className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700 dark:active:bg-blue-800"
               disabled={!name.trim() || !password}
             >
               Login
             </button>
           </form>
-          <p className="text-center text-sm text-gray-600">
+          <p className="text-center text-sm text-gray-600 dark:text-gray-400">
             Don't have an account?{" "}
-            <Link to="/signup" className="text-blue-500">
+            <Link to="/signup" className="text-blue-500 dark:text-blue-400">
               Sign up
             </Link>
           </p>

--- a/scorecard-webapp/src/pages/Login.tsx
+++ b/scorecard-webapp/src/pages/Login.tsx
@@ -19,7 +19,9 @@ export default function Login() {
     <div className="flex h-dvh w-full overflow-hidden bg-gray-50 dark:bg-gray-950">
       <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-900">
         <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow dark:bg-gray-900">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Simple Scorecard</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Simple Scorecard
+          </h1>
         </div>
         <div className="flex flex-1 flex-col gap-6 p-6">
           <p className="text-center text-gray-600 dark:text-gray-400">

--- a/scorecard-webapp/src/pages/NotFound.tsx
+++ b/scorecard-webapp/src/pages/NotFound.tsx
@@ -4,8 +4,12 @@ export default function NotFound() {
   return (
     <div className="flex h-dvh w-full items-center justify-center bg-gray-50 text-center dark:bg-gray-950">
       <div>
-        <h1 className="text-6xl font-bold text-gray-800 dark:text-gray-100">404</h1>
-        <p className="mb-4 text-xl text-gray-600 dark:text-gray-400">Page Not Found</p>
+        <h1 className="text-6xl font-bold text-gray-800 dark:text-gray-100">
+          404
+        </h1>
+        <p className="mb-4 text-xl text-gray-600 dark:text-gray-400">
+          Page Not Found
+        </p>
         <p className="mb-8 text-gray-500 dark:text-gray-400">
           Sorry, the page you are looking for does not exist.
         </p>

--- a/scorecard-webapp/src/pages/NotFound.tsx
+++ b/scorecard-webapp/src/pages/NotFound.tsx
@@ -2,16 +2,16 @@ import { Link } from "react-router";
 
 export default function NotFound() {
   return (
-    <div className="flex h-dvh w-full items-center justify-center bg-gray-50 text-center">
+    <div className="flex h-dvh w-full items-center justify-center bg-gray-50 text-center dark:bg-gray-950">
       <div>
-        <h1 className="text-6xl font-bold text-gray-800">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Page Not Found</p>
-        <p className="mb-8 text-gray-500">
+        <h1 className="text-6xl font-bold text-gray-800 dark:text-gray-100">404</h1>
+        <p className="mb-4 text-xl text-gray-600 dark:text-gray-400">Page Not Found</p>
+        <p className="mb-8 text-gray-500 dark:text-gray-400">
           Sorry, the page you are looking for does not exist.
         </p>
         <Link
           to="/"
-          className="rounded-lg bg-blue-500 px-6 py-3 font-medium text-white transition-colors hover:bg-blue-600"
+          className="rounded-lg bg-blue-500 px-6 py-3 font-medium text-white transition-colors hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700"
         >
           Go back to Home
         </Link>

--- a/scorecard-webapp/src/pages/Profile.test.tsx
+++ b/scorecard-webapp/src/pages/Profile.test.tsx
@@ -13,7 +13,7 @@ test("shows user info and allows navigation and logout", async () => {
   const setUser = vi.fn();
   render(
     <AppStateContext.Provider
-      value={{ user: { id: "123", name: "Alice" }, setUser, course: null, setCourse: vi.fn() }}
+      value={{ user: { id: "123", name: "Alice" }, setUser, course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}
     >
       <Profile />
     </AppStateContext.Provider>,

--- a/scorecard-webapp/src/pages/Profile.tsx
+++ b/scorecard-webapp/src/pages/Profile.tsx
@@ -13,26 +13,26 @@ export default function Profile() {
   };
 
   return (
-    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
-      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
-        <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow">
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50 dark:bg-gray-950">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-900">
+        <div className="flex h-20 flex-shrink-0 items-center rounded-t-lg bg-white p-4 shadow dark:bg-gray-900">
           <button
-            className="cursor-pointer rounded-lg bg-gray-200 px-4 py-2 transition-colors hover:bg-gray-300"
+            className="cursor-pointer rounded-lg bg-gray-200 px-4 py-2 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
             onClick={handleGoBack}
             aria-label="Back"
           >
             ←
           </button>
-          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900">
+          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900 dark:text-gray-100">
             Profile
           </h1>
           <div className="w-12" />
         </div>
         <div className="flex-1 overflow-y-auto overscroll-contain p-6">
-          <p className="mb-2">
+          <p className="mb-2 text-gray-700 dark:text-gray-300">
             <span className="font-semibold">Name:</span> {user.name}
           </p>
-          <p className="mb-4">
+          <p className="mb-4 text-gray-700 dark:text-gray-300">
             <span className="font-semibold">ID:</span> {user.id}
           </p>
           <LogoutButton />

--- a/scorecard-webapp/src/pages/Scorecard.test.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.test.tsx
@@ -14,7 +14,7 @@ function renderScorecard(course: CourseState) {
   const setCourse = vi.fn();
   const setUser = vi.fn();
   render(
-    <AppStateContext.Provider value={{ course, setCourse, user: null, setUser }}>
+    <AppStateContext.Provider value={{ course, setCourse, user: null, setUser, theme: "light", setTheme: vi.fn() }}>
       <Scorecard />
     </AppStateContext.Provider>,
   );

--- a/scorecard-webapp/src/pages/Scorecard.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.tsx
@@ -80,37 +80,37 @@ export default function Scorecard() {
   const relativeScore = hasPar ? totalStrokes - (totalPar ?? 0) : null;
 
   return (
-    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
-      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
-        <div className="flex h-20 flex-shrink-0 items-center justify-between rounded-t-lg bg-white p-4 shadow">
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50 dark:bg-gray-950">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-900">
+        <div className="flex h-20 flex-shrink-0 items-center justify-between rounded-t-lg bg-white p-4 shadow dark:bg-gray-900">
           <button
-            className="cursor-pointer rounded-lg bg-gray-200 px-4 py-2 transition-colors hover:bg-gray-300"
+            className="cursor-pointer rounded-lg bg-gray-200 px-4 py-2 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
             onClick={handleGoBack}
             aria-label="Back"
           >
             ←
           </button>
-          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900">
+          <h1 className="flex-1 text-center text-2xl font-bold text-gray-900 dark:text-gray-100">
             {course.name}
           </h1>
           {hasPar && totalPar !== null ? (
-            <span className="ml-2 text-sm font-semibold text-blue-600">
+            <span className="ml-2 text-sm font-semibold text-blue-600 dark:text-blue-400">
               Par {totalPar}
             </span>
           ) : (
             <div className="w-12" />
           )}
         </div>
-        <ul className="flex-1 divide-y divide-gray-200 overflow-y-auto overscroll-contain px-4 py-2">
+        <ul className="flex-1 divide-y divide-gray-200 overflow-y-auto overscroll-contain px-4 py-2 dark:divide-gray-700">
           {course.holes.map((hole, i) => (
             <li
               key={hole.number}
               className="flex items-center justify-between py-3"
             >
-              <span className="text-lg font-medium text-gray-700">
+              <span className="text-lg font-medium text-gray-700 dark:text-gray-300">
                 Hole {hole.number}
                 {hasPar && hole.par > 0 && (
-                  <span className="ml-2 text-sm text-gray-500">
+                  <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">
                     Par {hole.par}
                   </span>
                 )}
@@ -118,7 +118,7 @@ export default function Scorecard() {
               <div className="flex items-center gap-4">
                 {strokes[i] > 0 && (
                   <button
-                    className="h-10 w-10 cursor-pointer rounded-lg bg-gray-200 transition-colors hover:bg-gray-300"
+                    className="h-10 w-10 cursor-pointer rounded-lg bg-gray-200 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
                     onClick={() => handleMinusClick(i)}
                   >
                     -
@@ -126,7 +126,7 @@ export default function Scorecard() {
                 )}
                 <span>{strokes[i]}</span>
                 <button
-                  className="h-10 w-10 cursor-pointer rounded-lg bg-blue-500 text-white transition-colors hover:bg-blue-600"
+                  className="h-10 w-10 cursor-pointer rounded-lg bg-blue-500 text-white transition-colors hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700"
                   onClick={() => handlePlusClick(i)}
                 >
                   +
@@ -135,10 +135,10 @@ export default function Scorecard() {
             </li>
           ))}
         </ul>
-        <div className="flex-shrink-0 rounded-b-lg bg-white p-4 shadow">
+        <div className="flex-shrink-0 rounded-b-lg bg-white p-4 shadow dark:bg-gray-900">
           <div className="mb-4 flex items-center justify-between">
-            <span className="text-lg font-semibold text-gray-700">Total</span>
-            <span className="flex items-center gap-2 text-2xl font-bold text-blue-600">
+            <span className="text-lg font-semibold text-gray-700 dark:text-gray-300">Total</span>
+            <span className="flex items-center gap-2 text-2xl font-bold text-blue-600 dark:text-blue-400">
               {totalStrokes}
               {hasPar && relativeScore !== null && (
                 <span
@@ -148,7 +148,7 @@ export default function Scorecard() {
                       ? "text-green-600"
                       : relativeScore > 0
                         ? "text-red-600"
-                        : "text-gray-500")
+                        : "text-gray-500 dark:text-gray-400")
                   }
                 >
                   {relativeScore > 0
@@ -162,7 +162,7 @@ export default function Scorecard() {
           </div>
           <button
             onClick={handleSaveRound}
-            className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700 dark:active:bg-blue-800"
             disabled={!isRoundComplete}
           >
             Save round

--- a/scorecard-webapp/src/pages/Scorecard.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.tsx
@@ -137,7 +137,9 @@ export default function Scorecard() {
         </ul>
         <div className="flex-shrink-0 rounded-b-lg bg-white p-4 shadow dark:bg-gray-900">
           <div className="mb-4 flex items-center justify-between">
-            <span className="text-lg font-semibold text-gray-700 dark:text-gray-300">Total</span>
+            <span className="text-lg font-semibold text-gray-700 dark:text-gray-300">
+              Total
+            </span>
             <span className="flex items-center gap-2 text-2xl font-bold text-blue-600 dark:text-blue-400">
               {totalStrokes}
               {hasPar && relativeScore !== null && (

--- a/scorecard-webapp/src/pages/Signup.test.tsx
+++ b/scorecard-webapp/src/pages/Signup.test.tsx
@@ -11,7 +11,7 @@ vi.mock("react-router", () => ({
 
 test("renders signup form", () => {
   render(
-    <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn() }}>
+    <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}>
       <Signup />
     </AppStateContext.Provider>,
   );

--- a/scorecard-webapp/src/pages/Signup.tsx
+++ b/scorecard-webapp/src/pages/Signup.tsx
@@ -21,7 +21,9 @@ export default function Signup() {
     <div className="flex h-dvh w-full overflow-hidden bg-gray-50 dark:bg-gray-950">
       <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-900">
         <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow dark:bg-gray-900">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Simple Scorecard</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Simple Scorecard
+          </h1>
         </div>
         <div className="flex flex-1 flex-col gap-6 p-6">
           <p className="text-center text-gray-600 dark:text-gray-400">

--- a/scorecard-webapp/src/pages/Signup.tsx
+++ b/scorecard-webapp/src/pages/Signup.tsx
@@ -18,13 +18,13 @@ export default function Signup() {
   };
 
   return (
-    <div className="flex h-dvh w-full overflow-hidden bg-gray-50">
-      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg">
-        <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow">
-          <h1 className="text-2xl font-bold text-gray-900">Simple Scorecard</h1>
+    <div className="flex h-dvh w-full overflow-hidden bg-gray-50 dark:bg-gray-950">
+      <div className="mx-auto flex h-full w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-900">
+        <div className="flex h-20 flex-shrink-0 items-center justify-center rounded-t-lg bg-white p-4 shadow dark:bg-gray-900">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Simple Scorecard</h1>
         </div>
         <div className="flex flex-1 flex-col gap-6 p-6">
-          <p className="text-center text-gray-600">
+          <p className="text-center text-gray-600 dark:text-gray-400">
             Create an account to start tracking your golf scores
           </p>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -32,33 +32,33 @@ export default function Signup() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Name"
-              className="rounded border p-2"
+              className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
             <input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="Email"
-              className="rounded border p-2"
+              className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Password"
-              className="rounded border p-2"
+              className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
             <button
               type="submit"
-              className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700 dark:active:bg-blue-800"
               disabled={!name.trim() || !email.trim() || !password}
             >
               Sign Up
             </button>
           </form>
-          <p className="text-center text-sm text-gray-600">
+          <p className="text-center text-sm text-gray-600 dark:text-gray-400">
             Already have an account?{" "}
-            <Link to="/login" className="text-blue-500">
+            <Link to="/login" className="text-blue-500 dark:text-blue-400">
               Login
             </Link>
           </p>

--- a/scorecard-webapp/tailwind.config.js
+++ b/scorecard-webapp/tailwind.config.js
@@ -1,5 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
-  darkMode: ['selector', '.dark'],
-};

--- a/scorecard-webapp/tailwind.config.js
+++ b/scorecard-webapp/tailwind.config.js
@@ -1,0 +1,5 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['selector', '.dark'],
+};

--- a/scorecard-webapp/tailwind.config.ts
+++ b/scorecard-webapp/tailwind.config.ts
@@ -1,6 +1,0 @@
-import type { Config } from 'tailwindcss';
-
-export default {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
-  darkMode: 'class',
-} satisfies Config;

--- a/scorecard-webapp/tailwind.config.ts
+++ b/scorecard-webapp/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+} satisfies Config;


### PR DESCRIPTION
## Summary
- support class-based dark mode via Tailwind configuration
- persist theme choice in context and localStorage
- add footer toggle and update UI styles for light/dark themes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987a19ecb4832288d1d29bc453c8d8