### PR TITLE
feat: add useLocalStorage hook

### DIFF
--- a/scorecard-webapp/index.html
+++ b/scorecard-webapp/index.html
@@ -7,10 +7,6 @@
     <title>Simple Scorecard</title>
   </head>
   <body>
-    <script>
-      const theme = localStorage.getItem('theme');
-      if (theme === 'dark') document.documentElement.classList.add('dark');
-    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/scorecard-webapp/src/context/AppStateContext.tsx
+++ b/scorecard-webapp/src/context/AppStateContext.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import { AppStateContext } from "./context";
 import type { CourseState } from "./context";
 import type { User } from "../models/User";
@@ -7,16 +8,13 @@ import type { User } from "../models/User";
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const [course, setCourse] = useState<CourseState | null>(null);
   const [user, setUser] = useState<User | null>(null);
-  const [theme, setTheme] = useState<"light" | "dark">(
-    () =>
-      (typeof window !== "undefined" &&
-        (localStorage.getItem("theme") as "light" | "dark")) ||
-      "light",
+  const [theme, setTheme] = useLocalStorage<"light" | "dark">(
+    "theme",
+    "light",
   );
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", theme === "dark");
-    localStorage.setItem("theme", theme);
   }, [theme]);
 
   return (

--- a/scorecard-webapp/src/context/AppStateContext.tsx
+++ b/scorecard-webapp/src/context/AppStateContext.tsx
@@ -8,10 +8,7 @@ import type { User } from "../models/User";
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const [course, setCourse] = useState<CourseState | null>(null);
   const [user, setUser] = useState<User | null>(null);
-  const [theme, setTheme] = useLocalStorage<"light" | "dark">(
-    "theme",
-    "light",
-  );
+  const [theme, setTheme] = useLocalStorage<"light" | "dark">("theme", "light");
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", theme === "dark");

--- a/scorecard-webapp/src/hooks/useLocalStorage.ts
+++ b/scorecard-webapp/src/hooks/useLocalStorage.ts
@@ -2,9 +2,13 @@ import { useEffect, useState } from "react";
 
 export function useLocalStorage<T>(key: string, initialValue: T) {
   const [value, setValue] = useState<T>(() => {
-    if (typeof window === "undefined") return initialValue;
+    if (typeof window === "undefined") {
+      return initialValue
+    };
     const item = window.localStorage.getItem(key);
-    if (item === null) return initialValue;
+    if (item === null) {
+      return initialValue
+    };
     try {
       return JSON.parse(item) as T;
     } catch {

--- a/scorecard-webapp/src/hooks/useLocalStorage.ts
+++ b/scorecard-webapp/src/hooks/useLocalStorage.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === "undefined") return initialValue;
+    const item = window.localStorage.getItem(key);
+    if (item === null) return initialValue;
+    try {
+      return JSON.parse(item) as T;
+    } catch {
+      return item as unknown as T;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}


### PR DESCRIPTION
## Summary
- add reusable `useLocalStorage` hook
- switch theme persistence to `useLocalStorage`
- remove direct `localStorage` usage in `index.html`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898c18502e88322a13ab851a82b2d32