### PR TITLE
refactor: extract course API calls to service

### DIFF
--- a/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
+++ b/scorecard-webapp/src/components/CourseList/PredefinedCoursesSelection.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { CourseSummary } from "../../models/CourseSummary";
 import { useAppState } from "../../context/useAppState";
 import { useNavigate } from "react-router";
-import type { Hole } from "../../models/Hole";
+import { getCourses, getCourse } from "../../services/courseService";
 
 export default function PredefinedCoursesSelection() {
   const { setCourse } = useAppState();
@@ -10,24 +10,22 @@ export default function PredefinedCoursesSelection() {
   const [courses, setCourses] = useState<CourseSummary[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // Initial fetch for main course list
   useEffect(() => {
-    fetch(`${import.meta.env.VITE_API_URL}/courses`)
-      .then((res) => res.json())
-      .then((data) => {
-        setCourses(data.courses || []);
+    async function fetchCourses() {
+      try {
+        const data = await getCourses();
+        setCourses(data);
+      } finally {
         setLoading(false);
-      })
-      .catch(() => setLoading(false));
+      }
+    }
+    fetchCourses();
   }, []);
 
   const handleSelectCourse = async (courseId: number) => {
     try {
-      const response = await fetch(
-        `${import.meta.env.VITE_API_URL}/courses/${courseId}`,
-      );
-      const data = await response.json();
-      setCourse({ name: data.name, holes: data.holes as Hole[] });
+      const course = await getCourse(courseId);
+      setCourse(course);
       navigate("/play");
     } catch (error) {
       alert(`Failed to load course data. ${error}`);

--- a/scorecard-webapp/src/context/AppStateContext.tsx
+++ b/scorecard-webapp/src/context/AppStateContext.tsx
@@ -2,11 +2,11 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { AppStateContext } from "./context";
-import type { CourseState } from "./context";
+import type { Course } from "../models/Course";
 import type { User } from "../models/User";
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
-  const [course, setCourse] = useState<CourseState | null>(null);
+  const [course, setCourse] = useState<Course | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [theme, setTheme] = useLocalStorage<"light" | "dark">("theme", "light");
 

--- a/scorecard-webapp/src/context/context.ts
+++ b/scorecard-webapp/src/context/context.ts
@@ -1,15 +1,10 @@
 import { createContext } from "react";
-import type { Hole } from "../models/Hole";
 import type { User } from "../models/User";
-
-export interface CourseState {
-  name: string;
-  holes: Hole[];
-}
+import type { Course } from "../models/Course";
 
 type AppState = {
-  course: CourseState | null;
-  setCourse: (course: CourseState | null) => void;
+  course: Course | null;
+  setCourse: (course: Course | null) => void;
   user: User | null;
   setUser: (user: User | null) => void;
   theme: "light" | "dark";

--- a/scorecard-webapp/src/models/Course.ts
+++ b/scorecard-webapp/src/models/Course.ts
@@ -1,0 +1,7 @@
+import type { Hole } from "./Hole";
+
+export interface Course {
+  name: string;
+  holes: Hole[];
+}
+

--- a/scorecard-webapp/src/pages/Scorecard.test.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Scorecard from "./Scorecard";
 import { AppStateContext } from "../context/context";
-import type { CourseState } from "../context/context";
+import type { Course } from "../models/Course";
 import { vi } from "vitest";
 
 vi.mock("react-router", () => ({
@@ -10,7 +10,7 @@ vi.mock("react-router", () => ({
   useBlocker: () => ({ state: "unblocked", proceed: vi.fn(), reset: vi.fn() }),
 }));
 
-function renderScorecard(course: CourseState) {
+function renderScorecard(course: Course) {
   const setCourse = vi.fn();
   const setUser = vi.fn();
   render(
@@ -21,7 +21,7 @@ function renderScorecard(course: CourseState) {
 }
 
 test("allows players to record strokes and enables save when round complete", async () => {
-  const course: CourseState = {
+  const course: Course = {
     name: "Test Course",
     holes: [
       { number: 1, par: 3 },

--- a/scorecard-webapp/src/services/courseService.ts
+++ b/scorecard-webapp/src/services/courseService.ts
@@ -1,0 +1,35 @@
+import type { CourseSummary } from "../models/CourseSummary";
+import type { Course } from "../models/Course";
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+async function get<T>(endpoint: string): Promise<T> {
+  const response = await fetch(`${API_URL}${endpoint}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${endpoint}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function getCourses(): Promise<CourseSummary[]> {
+  const data = await get<{ courses: CourseSummary[] }>("/courses");
+  return data.courses || [];
+}
+
+export async function getCourse(courseId: number): Promise<Course> {
+  return get<Course>(`/courses/${courseId}`);
+}
+
+export async function searchExternalCourses(
+  query: string,
+): Promise<CourseSummary[]> {
+  const data = await get<{ courses: CourseSummary[] }>(
+    `/external/courses/search?q=${encodeURIComponent(query)}`,
+  );
+  return data.courses || [];
+}
+
+export async function getExternalCourse(courseId: number): Promise<Course> {
+  return get<Course>(`/external/courses/${courseId}`);
+}
+


### PR DESCRIPTION
## Summary
- add course service for listing, fetching, and searching courses
- update CourseList components to use service layer
- introduce Course model and update app state context

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e5db9978832294cc94f9f4fa1ce0