### PR TITLE
Add User model and SQLite table setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ dist-ssr
 __pycache__
 scorecard-api/.env
 
+# Database
+*.db
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/scorecard-api/api/__init__.py
+++ b/scorecard-api/api/__init__.py
@@ -1,17 +1,29 @@
 from flask import Flask
 from flask_cors import CORS
+from flask_sqlalchemy import SQLAlchemy
+
 from .courses import courses_bp
 from .external_courses import external_courses_bp
 
+db = SQLAlchemy()
+
 
 def create_app():
-    """
-    Application factory for Flask app.
-    """
     app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///scorecard.db"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    db.init_app(app)
     CORS(app, origins=["http://localhost:5173", "https://rognoni-ignacio.github.io"])
+
     app.register_blueprint(courses_bp)
     app.register_blueprint(external_courses_bp)
+
+    with app.app_context():
+        from .models.user import User
+
+        db.create_all()
+
     return app
 
 

--- a/scorecard-api/api/models/user.py
+++ b/scorecard-api/api/models/user.py
@@ -1,45 +1,19 @@
-import os
-import sqlite3
-
-# Default path for SQLite database file
-DB_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "users.db"
-)
+from api import db
+from werkzeug.security import generate_password_hash, check_password_hash
 
 
-class User:
-    def __init__(self, id, email, password_hash, name):
-        self.id = id
-        self.email = email
-        self.password_hash = password_hash
-        self.name = name
+class User(db.Model):
+    __tablename__ = "users"
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, index=True, nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    password_hash = db.Column(db.String(256), nullable=False)
 
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "email": self.email,
-            "password_hash": self.password_hash,
-            "name": self.name,
-        }
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
 
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
 
-def create_users_table(db_path: str = DB_PATH) -> None:
-    """Create the users table if it doesn't already exist."""
-    connection = sqlite3.connect(db_path)
-    cursor = connection.cursor()
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS users (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            email TEXT UNIQUE NOT NULL,
-            password_hash TEXT NOT NULL,
-            name TEXT NOT NULL
-        )
-        """
-    )
-    connection.commit()
-    connection.close()
-
-
-if __name__ == "__main__":
-    create_users_table()
+    def to_dict(self) -> dict:
+        return {"id": self.id, "email": self.email, "name": self.name}

--- a/scorecard-api/api/models/user.py
+++ b/scorecard-api/api/models/user.py
@@ -1,0 +1,45 @@
+import os
+import sqlite3
+
+# Default path for SQLite database file
+DB_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "users.db"
+)
+
+
+class User:
+    def __init__(self, id, email, password_hash, name):
+        self.id = id
+        self.email = email
+        self.password_hash = password_hash
+        self.name = name
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "email": self.email,
+            "password_hash": self.password_hash,
+            "name": self.name,
+        }
+
+
+def create_users_table(db_path: str = DB_PATH) -> None:
+    """Create the users table if it doesn't already exist."""
+    connection = sqlite3.connect(db_path)
+    cursor = connection.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL,
+            name TEXT NOT NULL
+        )
+        """
+    )
+    connection.commit()
+    connection.close()
+
+
+if __name__ == "__main__":
+    create_users_table()

--- a/scorecard-api/requirements.txt
+++ b/scorecard-api/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.16.4
 blinker==1.9.0
 certifi==2025.7.14
 charset-normalizer==3.4.2
@@ -5,10 +6,14 @@ click==8.2.1
 colorama==0.4.6
 Flask==3.1.1
 flask-cors==6.0.1
+Flask-Migrate==4.1.0
+Flask-SQLAlchemy==3.1.1
+greenlet==3.2.4
 idna==3.10
 iniconfig==2.1.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
+Mako==1.3.10
 MarkupSafe==3.0.2
 packaging==25.0
 pluggy==1.6.0
@@ -16,5 +21,7 @@ Pygments==2.19.2
 pytest==8.4.1
 python-dotenv==1.1.1
 requests==2.32.4
+SQLAlchemy==2.0.43
+typing_extensions==4.14.1
 urllib3==2.5.0
 Werkzeug==3.1.3


### PR DESCRIPTION
## Summary
- add basic `User` model with id, email, password hash, and name fields
- provide helper to initialize `users` table in SQLite

## Testing
- `sqlite3 scorecard-api/api/users.db '.schema users'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b35fa07f0832288a2b1ea120890f5