### PR TITLE
Connect auth pages to Flask API

### DIFF
--- a/scorecard-webapp/src/components/AppFooter.test.tsx
+++ b/scorecard-webapp/src/components/AppFooter.test.tsx
@@ -9,6 +9,8 @@ test("renders link to GitHub repository", () => {
       value={{
         user: null,
         setUser: vi.fn(),
+        token: null,
+        setToken: vi.fn(),
         course: null,
         setCourse: vi.fn(),
         theme: "light",

--- a/scorecard-webapp/src/components/RequireAuth.tsx
+++ b/scorecard-webapp/src/components/RequireAuth.tsx
@@ -3,9 +3,12 @@ import { Navigate } from "react-router";
 import { useAppState } from "../context/useAppState";
 
 export default function RequireAuth({ children }: PropsWithChildren) {
-  const { user } = useAppState();
-  if (!user) {
+  const { user, token } = useAppState();
+  if (!user && !token) {
     return <Navigate to="/login" replace />;
+  }
+  if (!user && token) {
+    return null;
   }
   return children;
 }

--- a/scorecard-webapp/src/context/AppStateContext.tsx
+++ b/scorecard-webapp/src/context/AppStateContext.tsx
@@ -4,9 +4,11 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 import { AppStateContext } from "./context";
 import type { Course } from "../models/Course";
 import type { User } from "../models/User";
+import { getMe } from "../services/authService";
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const [course, setCourse] = useState<Course | null>(null);
+  const [token, setToken] = useLocalStorage<string | null>("token", null);
   const [user, setUser] = useState<User | null>(null);
   const [theme, setTheme] = useLocalStorage<"light" | "dark">("theme", "light");
 
@@ -14,9 +16,22 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
     document.documentElement.classList.toggle("dark", theme === "dark");
   }, [theme]);
 
+  useEffect(() => {
+    if (token) {
+      getMe(token)
+        .then(setUser)
+        .catch(() => {
+          setToken(null);
+          setUser(null);
+        });
+    } else {
+      setUser(null);
+    }
+  }, [token, setToken]);
+
   return (
     <AppStateContext.Provider
-      value={{ course, setCourse, user, setUser, theme, setTheme }}
+      value={{ course, setCourse, user, setUser, token, setToken, theme, setTheme }}
     >
       {children}
     </AppStateContext.Provider>

--- a/scorecard-webapp/src/context/context.ts
+++ b/scorecard-webapp/src/context/context.ts
@@ -7,6 +7,8 @@ type AppState = {
   setCourse: (course: Course | null) => void;
   user: User | null;
   setUser: (user: User | null) => void;
+  token: string | null;
+  setToken: (token: string | null) => void;
   theme: "light" | "dark";
   setTheme: (theme: "light" | "dark") => void;
 };

--- a/scorecard-webapp/src/hooks/useLogin.ts
+++ b/scorecard-webapp/src/hooks/useLogin.ts
@@ -1,12 +1,14 @@
 import { useNavigate } from "react-router";
 import { useAppState } from "../context/useAppState";
-import type { User } from "../models/User";
+import { login as loginService } from "../services/authService";
 
 export function useLogin() {
-  const { setUser } = useAppState();
+  const { setUser, setToken } = useAppState();
   const navigate = useNavigate();
-  return (user: User) => {
+  return async (email: string, password: string) => {
+    const { access_token, user } = await loginService({ email, password });
     setUser(user);
+    setToken(access_token);
     navigate("/");
   };
 }

--- a/scorecard-webapp/src/hooks/useLogout.ts
+++ b/scorecard-webapp/src/hooks/useLogout.ts
@@ -2,10 +2,11 @@ import { useNavigate } from "react-router";
 import { useAppState } from "../context/useAppState";
 
 export function useLogout() {
-  const { setUser } = useAppState();
+  const { setUser, setToken } = useAppState();
   const navigate = useNavigate();
   return () => {
     setUser(null);
+    setToken(null);
     navigate("/login");
   };
 }

--- a/scorecard-webapp/src/models/Auth.ts
+++ b/scorecard-webapp/src/models/Auth.ts
@@ -1,0 +1,17 @@
+import type { User } from "./User";
+
+export interface SignupRequest {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  access_token: string;
+  user: User;
+}

--- a/scorecard-webapp/src/models/User.ts
+++ b/scorecard-webapp/src/models/User.ts
@@ -1,4 +1,5 @@
 export interface User {
-  id: string;
+  id: number;
   name: string;
+  email: string;
 }

--- a/scorecard-webapp/src/pages/Login.test.tsx
+++ b/scorecard-webapp/src/pages/Login.test.tsx
@@ -11,7 +11,18 @@ vi.mock("react-router", () => ({
 
 test("renders app name and description", () => {
   render(
-    <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}>
+    <AppStateContext.Provider
+      value={{
+        user: null,
+        setUser: vi.fn(),
+        token: null,
+        setToken: vi.fn(),
+        course: null,
+        setCourse: vi.fn(),
+        theme: "light",
+        setTheme: vi.fn(),
+      }}
+    >
       <Login />
     </AppStateContext.Provider>,
   );
@@ -22,5 +33,6 @@ test("renders app name and description", () => {
   expect(
     screen.getByText(/track your golf scores with ease/i),
   ).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
   expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument();
 });

--- a/scorecard-webapp/src/pages/Login.tsx
+++ b/scorecard-webapp/src/pages/Login.tsx
@@ -4,15 +4,27 @@ import { useLogin } from "../hooks/useLogin";
 import AppFooter from "../components/AppFooter";
 
 export default function Login() {
-  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
   const login = useLogin();
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const trimmed = name.trim();
-    if (!trimmed || !password) return;
-    login({ id: crypto.randomUUID(), name: trimmed });
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail || !password) {
+      setError("Email and password are required");
+      return;
+    }
+    if (!/^\S+@\S+\.\S+$/.test(trimmedEmail)) {
+      setError("Invalid email");
+      return;
+    }
+    try {
+      await login(trimmedEmail, password);
+    } catch (err: any) {
+      setError(err.message);
+    }
   };
 
   return (
@@ -29,9 +41,10 @@ export default function Login() {
           </p>
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Name"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
               className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
             <input
@@ -41,10 +54,15 @@ export default function Login() {
               placeholder="Password"
               className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
+            {error && (
+              <p className="text-sm text-red-500" role="alert">
+                {error}
+              </p>
+            )}
             <button
               type="submit"
               className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700 dark:active:bg-blue-800"
-              disabled={!name.trim() || !password}
+              disabled={!email.trim() || !password}
             >
               Login
             </button>

--- a/scorecard-webapp/src/pages/Profile.test.tsx
+++ b/scorecard-webapp/src/pages/Profile.test.tsx
@@ -11,15 +11,26 @@ vi.mock("react-router", () => ({
 
 test("shows user info and allows navigation and logout", async () => {
   const setUser = vi.fn();
+  const setToken = vi.fn();
   render(
     <AppStateContext.Provider
-      value={{ user: { id: "123", name: "Alice" }, setUser, course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}
+      value={{
+        user: { id: 123, name: "Alice", email: "alice@example.com" },
+        setUser,
+        token: "token",
+        setToken,
+        course: null,
+        setCourse: vi.fn(),
+        theme: "light",
+        setTheme: vi.fn(),
+      }}
     >
       <Profile />
     </AppStateContext.Provider>,
   );
 
-  expect(screen.getByText(/alice/i)).toBeInTheDocument();
+  expect(screen.getByText("Alice")).toBeInTheDocument();
+  expect(screen.getByText(/alice@example.com/i)).toBeInTheDocument();
   expect(screen.getByText(/123/)).toBeInTheDocument();
 
   const user = userEvent.setup();
@@ -28,4 +39,5 @@ test("shows user info and allows navigation and logout", async () => {
 
   await user.click(screen.getByRole("button", { name: /logout/i }));
   expect(setUser).toHaveBeenCalledWith(null);
+  expect(setToken).toHaveBeenCalledWith(null);
 });

--- a/scorecard-webapp/src/pages/Profile.tsx
+++ b/scorecard-webapp/src/pages/Profile.tsx
@@ -32,6 +32,9 @@ export default function Profile() {
           <p className="mb-2 text-gray-700 dark:text-gray-300">
             <span className="font-semibold">Name:</span> {user.name}
           </p>
+          <p className="mb-2 text-gray-700 dark:text-gray-300">
+            <span className="font-semibold">Email:</span> {user.email}
+          </p>
           <p className="mb-4 text-gray-700 dark:text-gray-300">
             <span className="font-semibold">ID:</span> {user.id}
           </p>

--- a/scorecard-webapp/src/pages/Scorecard.test.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.test.tsx
@@ -14,7 +14,18 @@ function renderScorecard(course: Course) {
   const setCourse = vi.fn();
   const setUser = vi.fn();
   render(
-    <AppStateContext.Provider value={{ course, setCourse, user: null, setUser, theme: "light", setTheme: vi.fn() }}>
+    <AppStateContext.Provider
+      value={{
+        course,
+        setCourse,
+        user: null,
+        setUser,
+        token: null,
+        setToken: vi.fn(),
+        theme: "light",
+        setTheme: vi.fn(),
+      }}
+    >
       <Scorecard />
     </AppStateContext.Provider>,
   );

--- a/scorecard-webapp/src/pages/Signup.test.tsx
+++ b/scorecard-webapp/src/pages/Signup.test.tsx
@@ -11,7 +11,18 @@ vi.mock("react-router", () => ({
 
 test("renders signup form", () => {
   render(
-    <AppStateContext.Provider value={{ user: null, setUser: vi.fn(), course: null, setCourse: vi.fn(), theme: "light", setTheme: vi.fn() }}>
+    <AppStateContext.Provider
+      value={{
+        user: null,
+        setUser: vi.fn(),
+        token: null,
+        setToken: vi.fn(),
+        course: null,
+        setCourse: vi.fn(),
+        theme: "light",
+        setTheme: vi.fn(),
+      }}
+    >
       <Signup />
     </AppStateContext.Provider>,
   );

--- a/scorecard-webapp/src/pages/Signup.tsx
+++ b/scorecard-webapp/src/pages/Signup.tsx
@@ -2,19 +2,37 @@ import { type FormEvent, useState } from "react";
 import { Link } from "react-router";
 import { useLogin } from "../hooks/useLogin";
 import AppFooter from "../components/AppFooter";
+import { signup as signupService } from "../services/authService";
 
 export default function Signup() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
   const login = useLogin();
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const trimmedName = name.trim();
     const trimmedEmail = email.trim();
-    if (!trimmedName || !trimmedEmail || !password) return;
-    login({ id: crypto.randomUUID(), name: trimmedName });
+    if (!trimmedName || !trimmedEmail || !password) {
+      setError("All fields are required");
+      return;
+    }
+    if (!/^\S+@\S+\.\S+$/.test(trimmedEmail)) {
+      setError("Invalid email");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+    try {
+      await signupService({ name: trimmedName, email: trimmedEmail, password });
+      await login(trimmedEmail, password);
+    } catch (err: any) {
+      setError(err.message);
+    }
   };
 
   return (
@@ -50,6 +68,11 @@ export default function Signup() {
               placeholder="Password"
               className="rounded border p-2 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
+            {error && (
+              <p className="text-sm text-red-500" role="alert">
+                {error}
+              </p>
+            )}
             <button
               type="submit"
               className="w-full cursor-pointer rounded-lg bg-blue-500 py-4 text-xl font-bold text-white shadow transition-colors hover:bg-blue-600 active:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700 dark:active:bg-blue-800"

--- a/scorecard-webapp/src/services/authService.ts
+++ b/scorecard-webapp/src/services/authService.ts
@@ -1,0 +1,37 @@
+import type { User } from "../models/User";
+import type { LoginRequest, SignupRequest, AuthResponse } from "../models/Auth";
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_URL}${endpoint}`, options);
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error((data as { error?: string }).error || "Request failed");
+  }
+  return data as T;
+}
+
+export async function signup(data: SignupRequest): Promise<User> {
+  return request<User>("/auth/signup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function login(data: LoginRequest): Promise<AuthResponse> {
+  return request<AuthResponse>("/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function getMe(token: string): Promise<User> {
+  return request<User>("/auth/me", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Add auth service and API models for login, signup, and profile
- Persist JWT in app state and load user via `/auth/me`
- Validate login/signup inputs with error handling

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d0bcd35ac8322a6109c0895b41807