### PR TITLE
feat: add save round functionality

### DIFF
--- a/scorecard-webapp/src/models/Round.ts
+++ b/scorecard-webapp/src/models/Round.ts
@@ -1,0 +1,21 @@
+export interface RoundHole {
+  number: number;
+  par: number;
+  strokes: number;
+}
+
+export interface Round {
+  id: number;
+  course_id?: number | null;
+  name: string;
+  played_at: string;
+  holes: RoundHole[];
+  total_par: number;
+  total_strokes: number;
+}
+
+export interface SaveRoundRequest {
+  course_id?: number;
+  name: string;
+  holes: RoundHole[];
+}

--- a/scorecard-webapp/src/pages/Scorecard.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.tsx
@@ -65,7 +65,9 @@ export default function Scorecard() {
   };
 
   const handleSaveRound = async () => {
-    if (!course) return;
+    if (!course) {
+      return;
+    }
     if (!token) {
       alert("You must be logged in to save a round.");
       return;

--- a/scorecard-webapp/src/pages/Scorecard.tsx
+++ b/scorecard-webapp/src/pages/Scorecard.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { useAppState } from "../context/useAppState";
 import { useBlocker, useNavigate } from "react-router";
+import { saveRound } from "../services/roundService";
 
 export default function Scorecard() {
   const navigate = useNavigate();
-  const { course } = useAppState();
+  const { course, token } = useAppState();
   const [strokes, setStrokes] = useState<number[]>(
     Array(course?.holes.length ?? 0).fill(0),
   );
@@ -64,7 +65,28 @@ export default function Scorecard() {
   };
 
   const handleSaveRound = async () => {
-    alert("Feature to be added...");
+    if (!course) return;
+    if (!token) {
+      alert("You must be logged in to save a round.");
+      return;
+    }
+    const holes = course.holes.map((hole, i) => ({
+      number: hole.number,
+      par: hole.par,
+      strokes: strokes[i],
+    }));
+    try {
+      await saveRound(
+        {
+          name: course.name,
+          holes,
+        },
+        token,
+      );
+      alert("Round saved!");
+    } catch (error) {
+      alert(`Failed to save round. ${error}`);
+    }
   };
 
   const isRoundComplete = strokes.every((stroke) => stroke > 0);

--- a/scorecard-webapp/src/services/roundService.ts
+++ b/scorecard-webapp/src/services/roundService.ts
@@ -1,0 +1,31 @@
+import type { Round, SaveRoundRequest } from "../models/Round";
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+async function request<T>(endpoint: string, token: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_URL}${endpoint}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      ...(options && options.headers ? options.headers : {}),
+    },
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error((data as { error?: string }).error || "Request failed");
+  }
+  return data as T;
+}
+
+export async function saveRound(data: SaveRoundRequest, token: string): Promise<Round> {
+  return request<Round>("/rounds", token, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function getRounds(token: string): Promise<Round[]> {
+  const data = await request<{ rounds: Round[] }>("/rounds", token);
+  return data.rounds || [];
+}


### PR DESCRIPTION
## Summary
- add `Round` models for round persistence
- create `roundService` to call API for saving and listing rounds
- wire up `Save round` button to post round data with auth token

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbe34b5083229a8c33437ea186f4